### PR TITLE
インクリメンタルサーチ

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,0 +1,53 @@
+$(function() {
+  $(document).on("click", ".user-search-add", function () {
+      var user_id = $(this).attr("data-user-id");
+      var user_name = $(this).attr("data-user-name");
+      selectUserName(user_id, user_name);
+      $(this).parent().remove();
+    })
+    $(document).on("click", ".user-search-remove", function () {
+      $(this).parent().remove();
+    })
+
+var search_list = $("#user-search-result");
+var select_list = $("#chat-group-users");
+
+function appendUserName(user) {
+   var html = `<div class="chat-group-user clearfix addmember">
+                <p class="chat-group-user__name">${ user.name }</p>
+                <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }"  data-user-name="${ user.name }">追加</div>
+              </div>`
+    search_list.append(html);
+  }
+
+function selectUserName(user_id, user_name) {
+   var remove_html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                        <input name='group[user_ids][]' type='hidden' value='${ user_id }'>
+                        <p class='chat-group-user__name'>${ user_name }</p>
+                        <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+                      </div>`
+    select_list.append(remove_html);
+  }
+
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUserName(user);
+        });
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    })
+  });
+});

--- a/app/assets/stylesheets/_chat-main.scss
+++ b/app/assets/stylesheets/_chat-main.scss
@@ -28,11 +28,13 @@
       letter-spacing: 2px;
       padding-bottom: 10px;
     }
-    .user {
+    p {
       font-size: 12px;
       color: #999999;
       line-height: 20px;
+      display: inline-block;
     }
+    
   }
   &__right {
     float: right;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  #before_action :set_group, only: [:edit, :update]
+  before_action :set_group, only: [:edit, :update]
 
   def index
   end
@@ -32,7 +32,7 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, {:user_ids => [] })
+    params.require(:group).permit(:name, user_ids: [] )
   end
 
   def set_group

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,11 @@
 class UsersController < ApplicationController
 
   def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
   
   def edit

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,19 +7,31 @@
           %li= message
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :name, class: 'chat-group-form__label'
+      %label.chat-group-form__label{for: "chat_group_name"} グループ名
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label チャットメンバーを追加
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
+      = f.label :user_ids, "チャットメンバー", class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      #chat-group-users
+        - @group.users.each do |user|
+          #chat-group-user-8.chat-group-user.clearfix.js-chat-member
+            %input{:name => "group[user_ids][]", :type => "hidden", :value  => "#{ user.id }"}/
+            %p.chat-group-user__name
+              = user.name
+            %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__firld--left
     .chat-group-form__field--right
       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,26 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
   = render partial: 'form', locals: { group: @group }
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,21 @@
+.chat
+  .chat-side
+    .chat-user
+      .chat-user__name
+        %h3.header_user.name
+          = current_user.name
+      .chat-user__icon
+        %li.list
+          = link_to new_group_path do
+            = fa_icon 'pencil-square-o', class: 'icon'
+        %li.list
+          = link_to edit_user_path(current_user) do
+            = fa_icon 'cog', class: 'icon'
+    .chat-groups
+      - current_user.groups.each do |group|
+        .chat-group
+          = link_to group_messages_path(group) do
+            .chat-group__name
+              = group.name
+            .chat-group__message
+              = group.show_last_message

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,28 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
   = render 'form', { group: @group }
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -23,10 +23,14 @@
   .chat-main
     .chat-header
       .chat-header__left
-        %h2.group test-group
-        %p.user Members: test-user
+        %h2.group 
+          = @group.name
+        %p.user Members: 
+        - @group.users.each do |user|
+          %span
+            = user.name
       .chat-header__right
-        %p.edit-btn Edit
+        = link_to 'edit', edit_group_path(@group), class: 'edit-btn'
     
     .chat-messages
       = render @messages

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
#what
グループの編集、新規チャットグループを作る際のユーザー検索をインクリメンタルサーチし、表示する。
#why
検索するたびに画面にリダイレクトさせず、ビューが毎回再描画されないようにする。

削除ボタンを押した時の動き↓
![deleteuser](https://user-images.githubusercontent.com/52647298/63993078-d9d19700-cb29-11e9-92b6-df4e7ad544ad.gif)


追加ボタンを押した時の動き↓
![adduser](https://user-images.githubusercontent.com/52647298/63993087-e2c26880-cb29-11e9-9358-697f3ecb4813.gif)


新規グループ作成した時の動き↓
![newgroup](https://user-images.githubusercontent.com/52647298/63993109-f8379280-cb29-11e9-8110-128dddb81a7a.gif)



