### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function() {
   function buildHTML(message){
     var imagehtml =message.image == null ? "" : `<img src="${message.image}" class="lower-message__image">`
-    var html = `<div class="chat-message">
+    var html = `<div class="chat-message" data-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${ message.user_name }
@@ -44,4 +44,24 @@ $(function() {
       $('.form__submit').prop('disabled', false);
     })
   })
+  var reloadMessages = function() {
+    last_message_id = $('.chat-message').last().data('id');
+    $.ajax({
+      url: 'api/messages',
+      type: 'GET',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      messages.forEach(function(message) {
+        insertHTML = buildHTML(message);
+        $('.chat-messages').append(insertHTML);
+        $('.chat-messages').animate({scrollTop: $('.chat-messages')[0].scrollHeight},'fast');
+      });
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -40,7 +40,7 @@ $(function() {
       $('.hidden').val('');
     })
     .fail(function(){
-      alert('error')
+      alert('メッセージ送信ができませんでした')
       $('.form__submit').prop('disabled', false);
     })
   })
@@ -60,7 +60,7 @@ $(function() {
       });
     })
     .fail(function() {
-      console.log('error');
+      alert('自動更新ができませんでした');
     });
   };
   setInterval(reloadMessages, 5000);

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-message
+.chat-message{data: {id: message.id}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
画面の自動更新機能を実装しました。

#why 
非同期通信機能のみでは別のユーザーが投稿したメッセージはリロードしなければ表示されないため。


テキストを入力した時動き↓
![autoupdate](https://user-images.githubusercontent.com/52647298/64111003-8fb51380-cdbe-11e9-8cdd-03f482c69a02.gif)

画像を投稿した時の動き↓
![autoupdateimg](https://user-images.githubusercontent.com/52647298/64111073-c12ddf00-cdbe-11e9-8b93-8ad4519e846f.gif)



